### PR TITLE
Use i18n to translate articles heading

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,5 +8,4 @@ class ApplicationController < ActionController::Base
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  around_action :switch_locale
+
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+    I18n.with_locale(locale, &action)
+  end
+
 end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Articles</h1>
+<h1><%= t ".title" %></h1>
 <div>
   <%= link_to 'New Article', new_article_path if authenticated? %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,4 +28,6 @@
 #       enabled: "ON"
 
 en:
-  hello: "Hello world"
+  articles: 
+    index:
+      title: "Article"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,0 +1,4 @@
+pl:
+  articles: 
+    index:
+      title: "Artykuł"


### PR DESCRIPTION
Used i18n to translate articles heading in english and polish. Based on [15 Internationalization (I18n)](https://guides.rubyonrails.org/getting_started.html#internationalization-i18n) from [Getting Started with Rails](https://guides.rubyonrails.org/getting_started.html)